### PR TITLE
Mutable Resources (resource pointers)

### DIFF
--- a/src/extension/grpc_vsock.rs
+++ b/src/extension/grpc_vsock.rs
@@ -100,6 +100,7 @@ fn create_endpoint_and_service<E: VmmExecutor, S: ProcessSpawner, R: Runtime, C:
         .as_ref()
         .ok_or(VmVsockGrpcError::VsockNotConfigured)?
         .uds
+        .clone()
         .get_effective_path()
         .ok_or(VmVsockGrpcError::VsockResourceUninitialized)?;
 

--- a/src/extension/http_vsock.rs
+++ b/src/extension/http_vsock.rs
@@ -167,6 +167,7 @@ impl<E: VmmExecutor, S: ProcessSpawner, R: Runtime> VmVsockHttp for Vm<E, S, R> 
             .as_ref()
             .ok_or(VmVsockHttpError::VsockNotConfigured)?
             .uds
+            .clone()
             .get_effective_path()
             .ok_or(VmVsockHttpError::VsockResourceUninitialized)?;
         let stream = <R::SocketBackend as hyper_client_sockets::Backend>::connect_to_firecracker_socket(
@@ -201,6 +202,7 @@ impl<E: VmmExecutor, S: ProcessSpawner, R: Runtime> VmVsockHttp for Vm<E, S, R> 
             .as_ref()
             .ok_or(VmVsockHttpError::VsockNotConfigured)?
             .uds
+            .clone()
             .get_effective_path()
             .ok_or(VmVsockHttpError::VsockResourceUninitialized)?;
 

--- a/src/vm/api.rs
+++ b/src/vm/api.rs
@@ -282,7 +282,7 @@ impl<E: VmmExecutor, S: ProcessSpawner, R: Runtime> VmApi for Vm<E, S, R> {
         send_api_request_with_response(self, "/machine-config", "GET", None::<i32>).await
     }
 
-    async fn create_snapshot(&mut self, create_snapshot: CreateSnapshot) -> Result<VmSnapshot, VmApiError> {
+    async fn create_snapshot(&mut self, mut create_snapshot: CreateSnapshot) -> Result<VmSnapshot, VmApiError> {
         self.ensure_state(VmState::Paused)
             .map_err(VmApiError::StateCheckError)?;
         send_api_request(self, "/snapshot/create", "PUT", Some(&create_snapshot)).await?;

--- a/src/vm/snapshot.rs
+++ b/src/vm/snapshot.rs
@@ -90,7 +90,7 @@ impl VmSnapshot {
             .create_resource(self.snapshot_path, ResourceType::Moved(options.moved_resource_type))
             .map_err(VmError::ResourceSystemError)?;
 
-        for resource in old_vm.get_resource_system().get_resources() {
+        for mut resource in old_vm.get_resource_system().get_resources() {
             if let ResourceType::Moved(_) = resource.get_type() {
                 let resource_path = resource.get_effective_path().ok_or_else(|| {
                     VmError::ResourceSystemError(ResourceSystemError::IncorrectState(ResourceState::Uninitialized))

--- a/src/vmm/executor/either.rs
+++ b/src/vmm/executor/either.rs
@@ -47,7 +47,7 @@ impl<J: LocalPathResolver + 'static> VmmExecutor for EitherVmmExecutor<J> {
 
     async fn prepare<S: ProcessSpawner, R: Runtime>(
         &self,
-        context: VmmExecutorContext<'_, S, R>,
+        context: VmmExecutorContext<S, R>,
     ) -> Result<(), VmmExecutorError> {
         match self {
             EitherVmmExecutor::Unrestricted(executor) => executor.prepare(context).await,
@@ -57,7 +57,7 @@ impl<J: LocalPathResolver + 'static> VmmExecutor for EitherVmmExecutor<J> {
 
     async fn invoke<S: ProcessSpawner, R: Runtime>(
         &self,
-        context: VmmExecutorContext<'_, S, R>,
+        context: VmmExecutorContext<S, R>,
         config_path: Option<PathBuf>,
     ) -> Result<ProcessHandle<R>, VmmExecutorError> {
         match self {
@@ -68,7 +68,7 @@ impl<J: LocalPathResolver + 'static> VmmExecutor for EitherVmmExecutor<J> {
 
     async fn cleanup<S: ProcessSpawner, R: Runtime>(
         &self,
-        context: VmmExecutorContext<'_, S, R>,
+        context: VmmExecutorContext<S, R>,
     ) -> Result<(), VmmExecutorError> {
         match self {
             EitherVmmExecutor::Unrestricted(executor) => executor.cleanup(context).await,

--- a/src/vmm/executor/jailed.rs
+++ b/src/vmm/executor/jailed.rs
@@ -64,7 +64,7 @@ impl<P: LocalPathResolver> VmmExecutor for JailedVmmExecutor<P> {
 
     async fn prepare<S: ProcessSpawner, R: Runtime>(
         &self,
-        context: VmmExecutorContext<'_, S, R>,
+        context: VmmExecutorContext<S, R>,
     ) -> Result<(), VmmExecutorError> {
         // Create the jail and delete the previous one if necessary
         let (chroot_base_dir, jail_path) = self.get_paths(&context.installation);
@@ -107,7 +107,7 @@ impl<P: LocalPathResolver> VmmExecutor for JailedVmmExecutor<P> {
             }
         }
 
-        for resource in context.resources.iter().chain(self.vmm_arguments.get_resources()) {
+        for mut resource in context.resources.chain(self.vmm_arguments.get_resources()) {
             match resource.get_type() {
                 ResourceType::Created(_) | ResourceType::Produced => {
                     resource.start_initialization(jail_path.jail_join(&resource.get_source_path()), None)
@@ -129,7 +129,7 @@ impl<P: LocalPathResolver> VmmExecutor for JailedVmmExecutor<P> {
 
     async fn invoke<S: ProcessSpawner, R: Runtime>(
         &self,
-        context: VmmExecutorContext<'_, S, R>,
+        context: VmmExecutorContext<S, R>,
         config_path: Option<PathBuf>,
     ) -> Result<ProcessHandle<R>, VmmExecutorError> {
         downgrade_owner_recursively(
@@ -205,7 +205,7 @@ impl<P: LocalPathResolver> VmmExecutor for JailedVmmExecutor<P> {
 
     async fn cleanup<S: ProcessSpawner, R: Runtime>(
         &self,
-        context: VmmExecutorContext<'_, S, R>,
+        context: VmmExecutorContext<S, R>,
     ) -> Result<(), VmmExecutorError> {
         let (_, jail_path) = self.get_paths(&context.installation);
 

--- a/src/vmm/executor/unrestricted.rs
+++ b/src/vmm/executor/unrestricted.rs
@@ -77,7 +77,7 @@ impl VmmExecutor for UnrestrictedVmmExecutor {
 
     async fn prepare<S: ProcessSpawner, R: Runtime>(
         &self,
-        context: VmmExecutorContext<'_, S, R>,
+        context: VmmExecutorContext<S, R>,
     ) -> Result<(), VmmExecutorError> {
         if let VmmApiSocket::Enabled(socket_path) = self.vmm_arguments.api_socket.clone() {
             let process_spawner = context.process_spawner.clone();
@@ -100,7 +100,7 @@ impl VmmExecutor for UnrestrictedVmmExecutor {
             }
         }
 
-        for resource in context.resources.iter().chain(self.vmm_arguments.get_resources()) {
+        for mut resource in context.resources.chain(self.vmm_arguments.get_resources()) {
             resource
                 .start_initialization_with_same_path()
                 .map_err(VmmExecutorError::ResourceSystemError)?;
@@ -111,7 +111,7 @@ impl VmmExecutor for UnrestrictedVmmExecutor {
 
     async fn invoke<S: ProcessSpawner, R: Runtime>(
         &self,
-        context: VmmExecutorContext<'_, S, R>,
+        context: VmmExecutorContext<S, R>,
         config_path: Option<PathBuf>,
     ) -> Result<ProcessHandle<R>, VmmExecutorError> {
         let mut arguments = self.vmm_arguments.join(config_path);
@@ -136,7 +136,7 @@ impl VmmExecutor for UnrestrictedVmmExecutor {
 
     async fn cleanup<S: ProcessSpawner, R: Runtime>(
         &self,
-        context: VmmExecutorContext<'_, S, R>,
+        context: VmmExecutorContext<S, R>,
     ) -> Result<(), VmmExecutorError> {
         if let VmmApiSocket::Enabled(socket_path) = self.vmm_arguments.api_socket.clone() {
             let process_spawner = context.process_spawner.clone();
@@ -159,7 +159,7 @@ impl VmmExecutor for UnrestrictedVmmExecutor {
             }
         }
 
-        for resource in context.resources.iter().chain(self.vmm_arguments.get_resources()) {
+        for mut resource in context.resources.chain(self.vmm_arguments.get_resources()) {
             if !matches!(resource.get_type(), ResourceType::Moved(_)) {
                 resource
                     .start_disposal()

--- a/src/vmm/process.rs
+++ b/src/vmm/process.rs
@@ -368,7 +368,7 @@ impl<E: VmmExecutor, S: ProcessSpawner, R: Runtime> VmmProcess<E, S, R> {
     }
 
     #[inline]
-    fn executor_context(&self) -> VmmExecutorContext<'_, S, R> {
+    fn executor_context(&self) -> VmmExecutorContext<S, R> {
         VmmExecutorContext {
             installation: self.installation.clone(),
             process_spawner: self.resource_system.process_spawner.clone(),

--- a/tests/extensions.rs
+++ b/tests/extensions.rs
@@ -223,6 +223,7 @@ async fn test_metrics_recv(is_fifo: bool, mut vm: TestVm) {
         .as_ref()
         .unwrap()
         .metrics
+        .clone()
         .get_effective_path()
         .unwrap();
 
@@ -253,6 +254,7 @@ fn metrics_task_can_be_cancelled_via_join_handle() {
                     .as_ref()
                     .unwrap()
                     .metrics
+                    .clone()
                     .get_effective_path()
                     .unwrap(),
                 100,

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -102,7 +102,7 @@ fn vm_logger_test(resource_type: CreatedResourceType) {
                 .as_ref()
                 .unwrap()
                 .logs
-                .as_ref()
+                .clone()
                 .unwrap()
                 .get_effective_path()
                 .unwrap();
@@ -140,6 +140,7 @@ fn vm_metrics_test(resource_type: CreatedResourceType) {
                 .as_ref()
                 .unwrap()
                 .metrics
+                .clone()
                 .get_effective_path()
                 .unwrap();
 
@@ -162,6 +163,7 @@ fn vm_processes_vsock() {
             .as_ref()
             .unwrap()
             .uds
+            .clone()
             .get_effective_path()
             .unwrap();
         assert!(metadata(&uds_path).await.unwrap().file_type().is_socket());


### PR DESCRIPTION
Another attempt to "synchronization primitives, but better" the resource system. If it doesn't prove to be good enough, reverting to the current state in master with `&self`-based Resources locking on a `Mutex<async_broadcast::Receiver<ResourcePull>>` will be done.