### PR TITLE
Majorly improved resource system V3 internals

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fctools"
-version = "0.6.0-rc.2"
+version = "0.6.0-rc.3"
 edition = "2021"
 description = "An exhaustive, highly modular and extensible host SDK for the Firecracker microVM manager."
 license = "MIT"
@@ -61,8 +61,6 @@ async-fs = { version = "2.1.2", optional = true }
 blocking = { version = "1.6.1", optional = true }
 pin-project-lite = { version = "0.2.15", optional = true }
 # vmm core
-async-broadcast = { version = "0.7.2", optional = true }
-# vmm executor
 futures-util = { version = "0.3.31", features = [
     "sink",
     "io",
@@ -155,13 +153,7 @@ process-spawner = []
 direct-process-spawner = ["process-spawner"]
 elevation-process-spawners = ["process-spawner", "dep:futures-util"]
 # L2: VMM core
-vmm-core = [
-    "process-spawner",
-    "dep:futures-util",
-    "dep:futures-channel",
-    "dep:async-broadcast",
-    "runtime-util",
-]
+vmm-core = ["process-spawner", "dep:futures-util", "dep:futures-channel"]
 # L3: VMM executor
 vmm-executor = ["vmm-core", "process-spawner", "dep:futures-channel"]
 jailed-vmm-executor = ["vmm-executor"]

--- a/src/vm/snapshot.rs
+++ b/src/vm/snapshot.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, sync::Arc};
+use std::path::PathBuf;
 
 use crate::{
     process_spawner::ProcessSpawner,
@@ -65,7 +65,7 @@ impl VmSnapshot {
             runtime.fs_copy(&self.snapshot_path, &new_snapshot_path),
             runtime.fs_copy(&self.mem_file_path, &new_mem_file_path)
         )
-        .map_err(|err| ResourceSystemError::FilesystemError(Arc::new(err)))?;
+        .map_err(ResourceSystemError::FilesystemError)?;
 
         self.snapshot_path = new_snapshot_path;
         self.mem_file_path = new_mem_file_path;

--- a/src/vmm/arguments/mod.rs
+++ b/src/vmm/arguments/mod.rs
@@ -23,7 +23,7 @@ pub struct VmmArguments {
     metadata_resource_index: Option<usize>,
     metrics_resource_index: Option<usize>,
     seccomp_filter_resource_index: Option<usize>,
-    resource_buffer: Vec<Resource>,
+    resources: Vec<Resource>,
 }
 
 impl VmmArguments {
@@ -43,7 +43,7 @@ impl VmmArguments {
             metadata_resource_index: None,
             metrics_resource_index: None,
             seccomp_filter_resource_index: None,
-            resource_buffer: Vec::new(),
+            resources: Vec::new(),
         }
     }
 
@@ -97,35 +97,35 @@ impl VmmArguments {
 
     /// Specify the [Resource] pointing to the log file for the VMM.
     pub fn logs(mut self, logs: Resource) -> Self {
-        self.resource_buffer.push(logs);
-        self.log_resource_index = Some(self.resource_buffer.len() - 1);
+        self.resources.push(logs);
+        self.log_resource_index = Some(self.resources.len() - 1);
         self
     }
 
     /// Specify the [Resource] pointing to the metadata file for the VMM.
     pub fn metadata(mut self, metadata: Resource) -> Self {
-        self.resource_buffer.push(metadata);
-        self.metadata_resource_index = Some(self.resource_buffer.len() - 1);
+        self.resources.push(metadata);
+        self.metadata_resource_index = Some(self.resources.len() - 1);
         self
     }
 
     /// Specify the [Resource] pointing to the metrics file for the VMM.
     pub fn metrics(mut self, metrics: Resource) -> Self {
-        self.resource_buffer.push(metrics);
-        self.metrics_resource_index = Some(self.resource_buffer.len() - 1);
+        self.resources.push(metrics);
+        self.metrics_resource_index = Some(self.resources.len() - 1);
         self
     }
 
     /// Specify the [Resource] pointing to a custom seccomp filter file for the VMM.
     pub fn seccomp_filter(mut self, seccomp_filter: Resource) -> Self {
-        self.resource_buffer.push(seccomp_filter);
-        self.seccomp_filter_resource_index = Some(self.resource_buffer.len() - 1);
+        self.resources.push(seccomp_filter);
+        self.seccomp_filter_resource_index = Some(self.resources.len() - 1);
         self
     }
 
     /// Get a shared slice into an internal buffer holding all [Resource]s tied to these [VmmArguments].
     pub fn get_resources(&self) -> &[Resource] {
-        &self.resource_buffer
+        &self.resources
     }
 
     /// Join these [VmmArguments] into a [Vec] of process arguments, using the given optional config path.
@@ -210,7 +210,7 @@ impl VmmArguments {
 
     #[inline(always)]
     fn get_resource_path_string(&self, index: usize) -> String {
-        self.resource_buffer
+        self.resources
             .get(index)
             .expect("Resource buffer doesn't contain index")
             .get_local_path()

--- a/src/vmm/resource/internal.rs
+++ b/src/vmm/resource/internal.rs
@@ -1,4 +1,12 @@
-use std::{future::poll_fn, path::PathBuf, pin::pin, sync::Arc, task::Poll};
+use std::{
+    future::poll_fn,
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, OnceLock,
+    },
+    task::Poll,
+};
 
 use futures_channel::mpsc;
 use futures_util::StreamExt;
@@ -11,43 +19,31 @@ use crate::{
 
 use super::{system::ResourceSystemError, CreatedResourceType, MovedResourceType, ResourceType};
 
-pub enum OwnedResourceState<R: Runtime> {
-    Uninitialized,
-    Initializing(R::Task<Result<ResourceInitData, ResourceSystemError>>),
-    Initialized,
-    Disposing(R::Task<Result<(), ResourceSystemError>>),
-    Disposed,
-}
-
-pub struct OwnedResource<R: Runtime> {
-    pub state: OwnedResourceState<R>,
-    pub request_rx: mpsc::UnboundedReceiver<ResourceRequest>,
-    pub response_tx: async_broadcast::Sender<ResourceResponse>,
-    pub data: Arc<ResourceData>,
-    pub init_data: Option<Arc<ResourceInitData>>,
-}
-
-#[derive(Debug, Clone)]
-pub struct ResourceData {
+#[derive(Debug)]
+pub struct ResourceInfo {
+    pub request_tx: mpsc::UnboundedSender<ResourceRequest>,
     pub source_path: PathBuf,
     pub r#type: ResourceType,
+    pub init_info: OnceLock<Arc<ResourceInitInfo>>,
+    pub disposed: AtomicBool,
 }
 
 #[derive(Debug, Clone)]
-pub struct ResourceInitData {
+pub struct ResourceInitInfo {
     pub effective_path: PathBuf,
     pub local_path: Option<PathBuf>,
 }
 
-pub enum ResourceRequest {
-    Initialize(ResourceInitData),
-    Dispose,
+pub struct OwnedResource<R: Runtime> {
+    pub init_task: Option<R::Task<Result<ResourceInitInfo, ResourceSystemError>>>,
+    pub dispose_task: Option<R::Task<Result<(), ResourceSystemError>>>,
+    pub request_rx: mpsc::UnboundedReceiver<ResourceRequest>,
+    pub info: Arc<ResourceInfo>,
 }
 
-#[derive(Debug, Clone)]
-pub enum ResourceResponse {
-    Initialized(Result<Arc<ResourceInitData>, ResourceSystemError>),
-    Disposed(Result<(), ResourceSystemError>),
+pub enum ResourceRequest {
+    Initialize(ResourceInitInfo),
+    Dispose,
 }
 
 pub enum ResourceSystemRequest<R: Runtime> {
@@ -71,13 +67,11 @@ pub async fn resource_system_main_task<S: ProcessSpawner, R: Runtime>(
     enum Incoming<R: Runtime> {
         SystemRequest(ResourceSystemRequest<R>),
         ResourceRequest(usize, ResourceRequest),
-        FinishedInitTask(usize, Result<ResourceInitData, ResourceSystemError>),
-        FinishedDisposeTask(usize, Result<(), ResourceSystemError>),
-        FinishedBroadcastTask(usize),
+        InitTaskCompletion(usize, Result<ResourceInitInfo, ResourceSystemError>),
+        DisposeTaskCompletion(usize, Result<(), ResourceSystemError>),
     }
 
     let mut synchronization_in_progress = false;
-    let mut broadcast_tasks = Vec::<R::Task<()>>::new();
 
     loop {
         let incoming = poll_fn(|cx| {
@@ -86,25 +80,21 @@ pub async fn resource_system_main_task<S: ProcessSpawner, R: Runtime>(
                     return Poll::Ready(Incoming::ResourceRequest(resource_index, request));
                 }
 
-                if let OwnedResourceState::Initializing(ref mut task) = resource.state {
+                if let Some(ref mut task) = resource.init_task {
                     if let Poll::Ready(Some(result)) = task.poll_join(cx) {
-                        return Poll::Ready(Incoming::FinishedInitTask(resource_index, result));
+                        resource.init_task = None;
+                        return Poll::Ready(Incoming::InitTaskCompletion(resource_index, result));
                     }
-                } else if let OwnedResourceState::Disposing(ref mut task) = resource.state {
+                } else if let Some(ref mut task) = resource.dispose_task {
                     if let Poll::Ready(Some(result)) = task.poll_join(cx) {
-                        return Poll::Ready(Incoming::FinishedDisposeTask(resource_index, result));
+                        resource.dispose_task = None;
+                        return Poll::Ready(Incoming::DisposeTaskCompletion(resource_index, result));
                     }
                 }
             }
 
             if let Poll::Ready(Some(request)) = request_rx.poll_next_unpin(cx) {
                 return Poll::Ready(Incoming::SystemRequest(request));
-            }
-
-            for (index, task) in broadcast_tasks.iter_mut().enumerate() {
-                if let Poll::Ready(Some(_)) = task.poll_join(cx) {
-                    return Poll::Ready(Incoming::FinishedBroadcastTask(index));
-                }
             }
 
             Poll::Pending
@@ -129,95 +119,66 @@ pub async fn resource_system_main_task<S: ProcessSpawner, R: Runtime>(
                 };
 
                 match request {
-                    ResourceRequest::Initialize(init_data) => {
+                    ResourceRequest::Initialize(init_info) => {
                         let init_task = runtime.spawn_task(resource_system_init_task(
-                            resource.data.clone(),
-                            init_data,
+                            resource.info.clone(),
+                            init_info,
                             runtime.clone(),
                             process_spawner.clone(),
                             ownership_model,
                         ));
 
-                        resource.state = OwnedResourceState::Initializing(init_task);
+                        resource.init_task = Some(init_task);
                     }
                     ResourceRequest::Dispose => {
                         let dispose_task = runtime.spawn_task(resource_system_dispose_task(
-                            resource.init_data.clone().unwrap(),
+                            resource.info.init_info.get().unwrap().clone(),
                             runtime.clone(),
                             process_spawner.clone(),
                             ownership_model,
                         ));
 
-                        resource.state = OwnedResourceState::Disposing(dispose_task);
+                        resource.dispose_task = Some(dispose_task);
                     }
                 }
             }
-            Incoming::FinishedInitTask(resource_index, result) => {
+            Incoming::InitTaskCompletion(resource_index, result) => {
                 let Some(resource) = owned_resources.get_mut(resource_index) else {
                     continue;
                 };
 
                 match result {
-                    Ok(init_data) => {
-                        let init_data = Arc::new(init_data);
-                        resource.init_data = Some(init_data.clone());
-                        resource.state = OwnedResourceState::Initialized;
-                        broadcast_tasks.push(defer_resource_pull(
-                            resource,
-                            &runtime,
-                            ResourceResponse::Initialized(Ok(init_data)),
-                        ));
+                    Ok(init_info) => {
+                        let _ = resource.info.init_info.set(Arc::new(init_info));
                     }
                     Err(err) => {
-                        resource.state = OwnedResourceState::Uninitialized;
-                        broadcast_tasks.push(defer_resource_pull(
-                            resource,
-                            &runtime,
-                            ResourceResponse::Initialized(Err(err)),
-                        ));
+                        // TODO handle error
+                        drop(err);
                     }
                 }
             }
-            Incoming::FinishedDisposeTask(resource_index, result) => {
+            Incoming::DisposeTaskCompletion(resource_index, result) => {
                 let Some(resource) = owned_resources.get_mut(resource_index) else {
                     continue;
                 };
 
                 match result {
                     Ok(_) => {
-                        resource.state = OwnedResourceState::Disposed;
-                        broadcast_tasks.push(defer_resource_pull(
-                            resource,
-                            &runtime,
-                            ResourceResponse::Disposed(Ok(())),
-                        ));
+                        resource.info.disposed.store(true, Ordering::Release);
                     }
                     Err(err) => {
-                        resource.state = OwnedResourceState::Initialized;
-                        broadcast_tasks.push(defer_resource_pull(
-                            resource,
-                            &runtime,
-                            ResourceResponse::Disposed(Err(err)),
-                        ));
+                        // TODO handle error
+                        drop(err);
                     }
                 }
-            }
-            Incoming::FinishedBroadcastTask(index) => {
-                broadcast_tasks.remove(index);
             }
         };
 
         if synchronization_in_progress {
             let pending_tasks = owned_resources
                 .iter()
-                .filter(|resource| {
-                    matches!(
-                        resource.state,
-                        OwnedResourceState::Initializing(_) | OwnedResourceState::Disposing(_)
-                    )
-                })
-                .count()
-                + broadcast_tasks.len();
+                .filter(|resource| resource.init_task.is_some() || resource.dispose_task.is_some())
+                .count();
 
             if pending_tasks == 0 {
                 synchronization_in_progress = false;
@@ -227,44 +188,32 @@ pub async fn resource_system_main_task<S: ProcessSpawner, R: Runtime>(
     }
 }
 
-#[inline]
-fn defer_resource_pull<R: Runtime>(
-    resource: &mut OwnedResource<R>,
-    runtime: &R,
-    pull: ResourceResponse,
-) -> R::Task<()> {
-    let tx = resource.response_tx.clone();
-    runtime.spawn_task(async move {
-        let _ = pin!(tx.broadcast_direct(pull)).await;
-    })
-}
-
 async fn resource_system_init_task<S: ProcessSpawner, R: Runtime>(
-    data: Arc<ResourceData>,
-    init_data: ResourceInitData,
+    info: Arc<ResourceInfo>,
+    init_info: ResourceInitInfo,
     runtime: R,
     process_spawner: S,
     ownership_model: VmmOwnershipModel,
-) -> Result<ResourceInitData, ResourceSystemError> {
-    match data.r#type {
+) -> Result<ResourceInitInfo, ResourceSystemError> {
+    match info.r#type {
         ResourceType::Moved(moved_resource_type) => {
-            if data.source_path == init_data.effective_path {
-                return Ok(init_data);
+            if info.source_path == init_info.effective_path {
+                return Ok(init_info);
             }
 
-            upgrade_owner(&data.source_path, ownership_model, &process_spawner, &runtime)
+            upgrade_owner(&info.source_path, ownership_model, &process_spawner, &runtime)
                 .await
                 .map_err(|err| ResourceSystemError::ChangeOwnerError(Arc::new(err)))?;
 
             if !runtime
-                .fs_exists(&data.source_path)
+                .fs_exists(&info.source_path)
                 .await
                 .map_err(|err| ResourceSystemError::FilesystemError(Arc::new(err)))?
             {
                 return Err(ResourceSystemError::SourcePathMissing);
             }
 
-            if let Some(parent_path) = init_data.effective_path.parent() {
+            if let Some(parent_path) = init_info.effective_path.parent() {
                 runtime
                     .fs_create_dir_all(parent_path)
                     .await
@@ -274,50 +223,50 @@ async fn resource_system_init_task<S: ProcessSpawner, R: Runtime>(
             match moved_resource_type {
                 MovedResourceType::Copied => {
                     runtime
-                        .fs_copy(&data.source_path, &init_data.effective_path)
+                        .fs_copy(&info.source_path, &init_info.effective_path)
                         .await
                         .map_err(|err| ResourceSystemError::FilesystemError(Arc::new(err)))?;
                 }
                 MovedResourceType::HardLinked => {
                     runtime
-                        .fs_hard_link(&data.source_path, &init_data.effective_path)
+                        .fs_hard_link(&info.source_path, &init_info.effective_path)
                         .await
                         .map_err(|err| ResourceSystemError::FilesystemError(Arc::new(err)))?;
                 }
                 MovedResourceType::CopiedOrHardLinked => {
                     if runtime
-                        .fs_copy(&data.source_path, &init_data.effective_path)
+                        .fs_copy(&info.source_path, &init_info.effective_path)
                         .await
                         .is_err()
                     {
                         runtime
-                            .fs_hard_link(&data.source_path, &init_data.effective_path)
+                            .fs_hard_link(&info.source_path, &init_info.effective_path)
                             .await
                             .map_err(|err| ResourceSystemError::FilesystemError(Arc::new(err)))?;
                     }
                 }
                 MovedResourceType::HardLinkedOrCopied => {
                     if runtime
-                        .fs_hard_link(&data.source_path, &init_data.effective_path)
+                        .fs_hard_link(&info.source_path, &init_info.effective_path)
                         .await
                         .is_err()
                     {
                         runtime
-                            .fs_copy(&data.source_path, &init_data.effective_path)
+                            .fs_copy(&info.source_path, &init_info.effective_path)
                             .await
                             .map_err(|err| ResourceSystemError::FilesystemError(Arc::new(err)))?;
                     }
                 }
                 MovedResourceType::Renamed => {
                     runtime
-                        .fs_rename(&data.source_path, &init_data.effective_path)
+                        .fs_rename(&info.source_path, &init_info.effective_path)
                         .await
                         .map_err(|err| ResourceSystemError::FilesystemError(Arc::new(err)))?;
                 }
             }
         }
         ResourceType::Created(created_resource_type) => {
-            if let Some(parent_path) = init_data.effective_path.parent() {
+            if let Some(parent_path) = init_info.effective_path.parent() {
                 runtime
                     .fs_create_dir_all(&parent_path)
                     .await
@@ -327,21 +276,21 @@ async fn resource_system_init_task<S: ProcessSpawner, R: Runtime>(
             match created_resource_type {
                 CreatedResourceType::File => {
                     runtime
-                        .fs_create_file(&init_data.effective_path)
+                        .fs_create_file(&init_info.effective_path)
                         .await
                         .map_err(|err| ResourceSystemError::FilesystemError(Arc::new(err)))?;
                 }
                 CreatedResourceType::Fifo => {
-                    crate::syscall::mkfifo(&init_data.effective_path)
+                    crate::syscall::mkfifo(&init_info.effective_path)
                         .map_err(|err| ResourceSystemError::FilesystemError(Arc::new(err)))?;
                 }
             }
 
-            downgrade_owner(&init_data.effective_path, ownership_model)
+            downgrade_owner(&init_info.effective_path, ownership_model)
                 .map_err(|err| ResourceSystemError::ChangeOwnerError(Arc::new(err)))?;
         }
         ResourceType::Produced => {
-            if let Some(parent_path) = init_data.effective_path.parent() {
+            if let Some(parent_path) = init_info.effective_path.parent() {
                 runtime
                     .fs_create_dir_all(&parent_path)
                     .await
@@ -353,21 +302,21 @@ async fn resource_system_init_task<S: ProcessSpawner, R: Runtime>(
         }
     };
 
-    Ok(init_data)
+    Ok(init_info)
 }
 
 async fn resource_system_dispose_task<R: Runtime, S: ProcessSpawner>(
-    init_data: Arc<ResourceInitData>,
+    init_info: Arc<ResourceInitInfo>,
     runtime: R,
     process_spawner: S,
     ownership_model: VmmOwnershipModel,
 ) -> Result<(), ResourceSystemError> {
-    upgrade_owner(&init_data.effective_path, ownership_model, &process_spawner, &runtime)
+    upgrade_owner(&init_info.effective_path, ownership_model, &process_spawner, &runtime)
         .await
         .map_err(|err| ResourceSystemError::ChangeOwnerError(Arc::new(err)))?;
 
     runtime
-        .fs_remove_file(&init_data.effective_path)
+        .fs_remove_file(&init_info.effective_path)
         .await
         .map_err(|err| ResourceSystemError::FilesystemError(Arc::new(err)))
 }

--- a/src/vmm/resource/mod.rs
+++ b/src/vmm/resource/mod.rs
@@ -168,12 +168,7 @@ impl Resource {
     /// resource is moved) path as its source path. This operation doesn't actually wait for the initialization
     /// to occur. This function may poll.
     pub fn start_initialization_with_same_path(&self) -> Result<(), ResourceSystemError> {
-        let local_path = match self.get_type() {
-            ResourceType::Moved(_) => Some(self.get_source_path()),
-            _ => None,
-        };
-
-        self.start_initialization(self.get_source_path(), local_path)
+        self.start_initialization(self.get_source_path(), Some(self.get_source_path()))
     }
 
     /// Schedule this [Resource] to be disposed by its system. This function may poll.


### PR DESCRIPTION
Very little or no breaking changes for the user, yet major (performance and usability) improvements on how the resource system is internally implemented:

1. `async-broadcast` crate is now no longer a dependency, only `futures-util` + `futures-channel` remain needed for the `mpsc` channel and `poll_next_unpin`
2. The cost of cloning a `Resource` is now that of cloning a single `Arc`, i.e. basically nothing at all, no more mutex locks and unlocks when cloning
3. `Resource` methods now no longer need to perform polling whatsoever! This means that simple operations like `Resource::get_effective_path` or `Resource::get_state` are now entirely instant (as they should be) other than, at most, an insignificant couple of atomic loads
4. The amount of different internal structs has been reduced: `ResourceResponse`, `OwnedResourceState` have been removed, and `Resource` is now merely a direct proxy to an `Arc<ResourceInfo>` (as indicated by point 1)
5. The `pull_rx/pull_tx` channel pair for the `Resource`/`OwnedResource` interaction and its overhead have been removed, as the internals directly modify the `ResourceInfo` pointed to by all `Resource`s, without having to send out notifications/channel messages
6. `ResourceSystemError` now doesn't need to implement `Clone`, meaning types like `Arc<std::io::Error>` are now replaced by owned variants